### PR TITLE
[WIP] Switch to an alpine base image

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -39,6 +39,13 @@ ENV METEOR_ALLOW_SUPERUSER true
 # Copy entrypoint and dependencies
 COPY ./docker $SCRIPTS_FOLDER/
 
+# Meteor bundles its own version of `node`, however it is not Alpine-based,
+# so copy over the one from the system $PATH instead.
+RUN bundled="$(find ~/.meteor/ -name node -type f)" && \
+  cp "$(which node)" "$bundled" && \
+  cd "$(dirname "$bundled")/../lib" && \
+  npm rebuild fibers --build-from-source
+
 # Install entrypoint dependencies
 RUN cd $SCRIPTS_FOLDER && \
 	meteor npm install

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,7 +1,7 @@
 # Based on:
 # - https://github.com/jshimko/meteor-launchpad/blob/master/Dockerfile
 # - https://github.com/meteor/galaxy-images/blob/master/ubuntu/Dockerfile
-FROM ubuntu
+FROM mhart/alpine-node:8.11.4
 
 # Default Meteor version if not defined at build time; see ../build.sh
 ARG METEOR_VERSION=1.6
@@ -11,9 +11,16 @@ ENV APP_SOURCE_FOLDER /opt/src
 ENV APP_BUNDLE_FOLDER /opt/bundle
 
 # Install dependencies, based on https://github.com/jshimko/meteor-launchpad/blob/master/scripts/install-deps.sh (only the parts we plan to use)
-RUN apt-get update && \
-	apt-get install --assume-yes apt-transport-https ca-certificates && \
-	apt-get install --assume-yes --no-install-recommends build-essential bsdtar bzip2 curl git python
+RUN apk add --no-cache \
+	bash \
+	build-base \
+	bzip2 \
+	ca-certificates \
+	curl \
+	tar \
+	git \
+	python \
+	libarchive-tools
 
 # Install Meteor
 RUN curl https://install.meteor.com --output /tmp/install-meteor.sh && \


### PR DESCRIPTION
Consider a Meteor project that uses a native C++ module.
For example `bcrypt`. Since we are building the dependencies
here in the Ubuntu base image, copying the resulting binary
over to the Alpine based runtime image will not work properly,
likely leading to segmentation faults due to the glibc vs. musl c
mismatch.

This commit attempts to fix that, however it doesn't actually
work since the image fails to build on the very last step, where
the `meteor` command is attempting to run its own bundled binary
of `node` rather than the one available in the `$PATH`. This similarly
fails due to the glib vs. musl c mismatch.

So I feel like this is a step in the right direction, however I'm
not yet sure how to get past the fact that `meteor` wants to invoke
its (incompatible) bundled version of `node` instead of the system one.