### PR TITLE
Make sure entrypoint.sh exits on connect.

### DIFF
--- a/src/docker/entrypoint.sh
+++ b/src/docker/entrypoint.sh
@@ -17,7 +17,9 @@ require('p-wait-for')(function() {
 			resolve(successfullyConnected);
 		});
 	});
-}, 1000);
+}, 1000).then(function() {
+        process.exit(0);
+});
 EOJS
 
 echo 'Starting app...'


### PR DESCRIPTION
I'm seeing the inline node script in `entrypoint.sh` hanging if it fails to connect and then later succeeds. I'm not sure exactly what's causing that, but this should make sure we definitely exit on success.