### PR TITLE
Create separate build-step to exclude build-packages from final image

### DIFF
--- a/example/app-with-native-dependencies.dockerfile
+++ b/example/app-with-native-dependencies.dockerfile
@@ -34,8 +34,25 @@ COPY --from=0 $SCRIPTS_FOLDER $SCRIPTS_FOLDER/
 # Copy in app bundle
 COPY --from=0 $APP_BUNDLE_FOLDER/bundle $APP_BUNDLE_FOLDER/bundle/
 
-RUN bash $SCRIPTS_FOLDER/build-meteor-npm-dependencies.sh --build-from-source \
-	&& apk del .node-gyp-compilation-dependencies
+RUN bash $SCRIPTS_FOLDER/build-meteor-npm-dependencies.sh --build-from-source
+
+
+# Use the specific version of Node expected by your Meteor release, per https://docs.meteor.com/changelog.html; this is expected for Meteor 1.9
+FROM node:12.14.0-alpine
+
+ENV APP_BUNDLE_FOLDER /opt/bundle
+ENV SCRIPTS_FOLDER /docker
+
+# Install runtime dependencies
+RUN apk --no-cache add \
+		bash \
+		ca-certificates
+
+# Copy in entrypoint
+COPY --from=1 $SCRIPTS_FOLDER $SCRIPTS_FOLDER/
+
+# Copy in app bundle
+COPY --from=1 $APP_BUNDLE_FOLDER/bundle $APP_BUNDLE_FOLDER/bundle/
 
 # Start app
 ENTRYPOINT ["/docker/entrypoint.sh"]


### PR DESCRIPTION
This only affects the image for native dependencies.

The old version of the build script installs a couple of build-scripts which later on are removed. A better approach for a smaller final image is to add an additional step for the actual rebuild.

Downside: Another copy command, which will delay each build.
Gain: Final image is about 100mb smaller (uncompressed) - even though these 100mb won't be fetched each time a new image is fetched and an old exists on the machine.

Another way of doing this (and avoiding the additional build step) would be to move the `RUN` command of line 22 after the two `COPY` statements and join it with the `RUN` command in line 37.

Let me know if the alternative approach is more appropriate. In this version (by adding an additional step) the system won't have to refetch all packages because it can reuse the layer of an older image. This benefit would fall away when combining it into a single `RUN` statement.