### PR TITLE
Skip waiting for MongoDB if not installed or configured.

### DIFF
--- a/src/docker/entrypoint.sh
+++ b/src/docker/entrypoint.sh
@@ -7,6 +7,12 @@ cd $SCRIPTS_FOLDER
 # Poll until we can successfully connect to MongoDB
 echo 'Connecting to MongoDB...'
 node <<- 'EOJS'
+// If mongodb doesn't exist do not attempt waiting for it.
+try { require.resolve('mongodb'); } catch { process.exit(0); };
+
+// Similarly, if MONGO_URL is not set, do not wait its startup.
+if (typeof process.env.MONGO_URL === 'undefined') process.exit(0);
+
 const mongoClient = require('mongodb').MongoClient;
 setInterval(function() {
 	mongoClient.connect(process.env.MONGO_URL, function(err, client) {


### PR DESCRIPTION
MongoDB is no longer an absolute requirement of all Meteor applications and can be optionally removed.

This adds a guard that skips the polling and waiting for Mongo to become available if either the 'mongodb' module is not present, or if the 'MONGO_URL' environment variable
is unset.

> Full-disclosure, I coded this entirely in the GitHub editor, but I suspect it should
> work well.  I'm not sure the best way to test this from the checkout though. 😉 