### PR TITLE
Add OOM error warning to build script; resolves #50

### DIFF
--- a/src/docker/build-meteor-bundle.sh
+++ b/src/docker/build-meteor-bundle.sh
@@ -2,7 +2,11 @@
 
 set -o errexit
 
-printf "\n[-] Building Meteor application bundle...\n\n"
+printf "\n[-] Building Meteor application bundle...\n"
+printf "\n    This container can use `free -m | grep Mem: | awk '{print $2}'`M memory in total."
+printf "\n    If it aborts with an out-of-memory (OOM) or ‘non-zero exit code 137’ error message,"
+printf "\n    please increase the container’s available memory.\n"
+printf "\n    See https://github.com/meteor/meteor/issues/9568 for details.\n\n"
 
 mkdir --parents $APP_BUNDLE_FOLDER
 


### PR DESCRIPTION
Meteor’s source map generation uses no GC, which can produce out-of-memory errors in CI environments with <4G RAM.

If this happens, the reason for killed containers can be difficult to track down. Some environments display a ‘OOMError’, some show a cryptic error message (‘non-zero exit code 137’), some show no error at all.

This adds a warning so you have a clue from the logs when the container is killed.

Related Meteor issue: https://github.com/meteor/meteor/issues/9568

The logs look like this:
```
Step 5/20 : RUN bash $SCRIPTS_FOLDER/build-meteor-bundle.sh
 ---> Running in 7ebb0bedc6cd

[-] Building Meteor application bundle...

    This container can use 3940M memory in total.
    If it aborts with an out-of-memory (OOM) or ‘non-zero exit code 137’ error message,
    please increase the container’s available memory.

    See https://github.com/meteor/meteor/issues/9568 for details.
```