### PR TITLE
readme fix repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Edit the `Dockerfile` you copied into your project, changing the first line so t
 FROM geoffreybooth/meteor-base:2.2
 ```
 
-if your project is running under Meteor 2.2. See your app’s `.meteor/release` file to get its Meteor release version. This version must match an available tag from [disney/meteor-base](https://hub.docker.com/r/geoffreybooth/meteor-base/tags).
+if your project is running under Meteor 2.2. See your app’s `.meteor/release` file to get its Meteor release version. This version must match an available tag from [geoffreybooth/meteor-base](https://hub.docker.com/r/geoffreybooth/meteor-base/tags).
 
 If necessary, update version in the `FROM node` line to use the Node version appropriate for your release of Meteor. From your application folder, you can get this version via the following command:
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Edit the `Dockerfile` you copied into your project, changing the first line so t
 FROM geoffreybooth/meteor-base:2.2
 ```
 
-if your project is running under Meteor 2.2. See your app’s `.meteor/release` file to get its Meteor release version. This version must match an available tag from [disney/meteor-base](https://cloud.docker.com/repository/docker/geoffreybooth/meteor-base/tags).
+if your project is running under Meteor 2.2. See your app’s `.meteor/release` file to get its Meteor release version. This version must match an available tag from [disney/meteor-base](https://hub.docker.com/r/geoffreybooth/meteor-base/tags).
 
 If necessary, update version in the `FROM node` line to use the Node version appropriate for your release of Meteor. From your application folder, you can get this version via the following command:
 


### PR DESCRIPTION
- 📝 docs(README): fix Docker Hub image link in favor of a public URL
- 📝 docs(README): use actual image repo name (geoffreybooth) instead of unexisting one (disney)
