### PR TITLE
📝 docs(README): refactor Quickstart with sections and more details

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ docker run --rm geoffreybooth/meteor-base:$(cat ./.meteor/release | cut -c8-99) 
 
 ### Step #3 - Setup your .dockerignore accordingly to speed up builds
 
-Also copy in `example/.dockerignore`
+Also copy the `example/.dockerignore` file to the root of your repository so that heavy non-needed files are not passed to the Docker context, so that your build is faster (for more, see the [`.dockerignore` documentation](https://docs.docker.com/engine/reference/builder/#dockerignore-file).
 
 ### Step #4 - Build & Profit 🎉
 

--- a/README.md
+++ b/README.md
@@ -14,13 +14,15 @@ Copy `example/default.dockerfile` (or `example/app-with-native-dependencies.dock
 
 ### Step #2 - Ensure the Meteor version is the one you want
 
-Edit the `Dockerfile` you copied into your project, changing the first line so that the numbers at the end match the version of Meteor of your project. For example:
+Edit the `Dockerfile` you copied into your project, changing the first line so that the numbers at the end match the version of Meteor of your project.
+
+For example if you project is running under Meteor 2.2:
 
 ```Dockerfile
 FROM geoffreybooth/meteor-base:2.2
 ```
 
-if your project is running under Meteor 2.2. See your app’s `.meteor/release` file to get its Meteor release version. This version must match an available tag from [geoffreybooth/meteor-base](https://hub.docker.com/r/geoffreybooth/meteor-base/tags).
+See your app’s `.meteor/release` file to get its Meteor release version. This version must match an available tag from [geoffreybooth/meteor-base](https://hub.docker.com/r/geoffreybooth/meteor-base/tags).
 
 If necessary, update version in the `FROM node` line to use the Node version appropriate for your release of Meteor. From your application folder, you can get this version via the following command:
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ docker-compose up
 
 This builds an image for your app and starts it, along with a linked container for MongoDB. Go to [http://localhost/](http://localhost/) to see your app running.
 
+### Going further
+
 Feel free to edit the `Dockerfile` you copied into your project, for example to add Linux dependencies. The beauty of the multistage build pattern is that this base image can stay lean, without needing `ONBUILD` triggers or configuration files for you to influence the image that gets built. You control the final image via your own `Dockerfile`, so you can do whatever you want.
 
 If you want any command run on startup before the Meteor app itself is run, have your Dockerfile save a file `startup.sh` into `$SCRIPTS_FOLDER`. It will be executed automatically by `entrypoint.sh`.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ docker build -t you-awesome-name/your-meteor-app-name .
 
 ### Step #5 (Optional) - Use Docker Compose to ease your workflow
 
-and `example/docker-compose.yml` to your project’s root. Then, from the root of your project:
+To make your workflow easier, you can also copy the `example/docker-compose.yml` file to your project’s root. Then, from the root of your project, run:
 
 ```bash
 docker-compose up

--- a/README.md
+++ b/README.md
@@ -8,21 +8,21 @@ This repo contains a base Docker image for use by [Meteor](https://www.meteor.co
 
 ## Quickstart
 
-### Step #1 - Bootstrap Dockerfile from template
+### Step 1: Bootstrap `Dockerfile` from template
 
 Copy `example/default.dockerfile` (or `example/app-with-native-dependencies.dockerfile` if your app has native dependencies that require compilation such as `bcrypt`, or if your app is using a version of Meteor older than 1.8.1) into the root of your project and rename it `Dockerfile`. This file assumes that your Meteor app is one level down from the root in a folder named `app`; either move your app there, or edit `Dockerfile` to point to your desired path (or the root of your project). Leave `Dockerfile` at the root.
 
-### Step #2 - Ensure the Meteor version is the one you want
+### Step 2: Set the correct Meteor version in the `Dockerfile`
 
-Edit the `Dockerfile` you copied into your project, changing the first line so that the numbers at the end match the version of Meteor of your project.
+Edit the `Dockerfile` you copied into your project, changing the first line so that the numbers at the end match the version of Meteor of your project. You can find your project’s Meteor version in your app’s `.meteor/release` file.
 
-For example if you project is running under Meteor 2.2:
+For example, if your project is running under Meteor 2.2:
 
 ```Dockerfile
 FROM geoffreybooth/meteor-base:2.2
 ```
 
-See your app’s `.meteor/release` file to get its Meteor release version. This version must match an available tag from [geoffreybooth/meteor-base](https://hub.docker.com/r/geoffreybooth/meteor-base/tags).
+This version must match an available tag from [geoffreybooth/meteor-base](https://hub.docker.com/r/geoffreybooth/meteor-base/tags).
 
 If necessary, update version in the `FROM node` line to use the Node version appropriate for your release of Meteor. From your application folder, you can get this version via the following command:
 
@@ -30,21 +30,13 @@ If necessary, update version in the `FROM node` line to use the Node version app
 docker run --rm geoffreybooth/meteor-base:$(cat ./.meteor/release | cut -c8-99) meteor node --version | cut -c2-99 | grep -o "[0-9\.]*"
 ```
 
-### Step #3 - Setup your .dockerignore accordingly to speed up builds
+### Step 3: Configure `.dockerignore` to speed up builds
 
-Also copy the `example/.dockerignore` file to the root of your repository so that heavy non-needed files are not passed to the Docker context, so that your build is faster (for more, see the [`.dockerignore` documentation](https://docs.docker.com/engine/reference/builder/#dockerignore-file).
+Copy `example/.dockerignore` to your project’s root and edit it appropriately to avoid copying unnecessary files into the Docker context.
 
-### Step #4 - Build & Profit 🎉
+### Step 4: Build and run
 
-Congratulations, you can know build the Docker image for your Meteor app in an easy and efficient way 🙂
-
-```bash
-docker build -t you-awesome-name/your-meteor-app-name .
-```
-
-### Step #5 (Optional) - Use Docker Compose to ease your workflow
-
-To make your workflow easier, you can also copy the `example/docker-compose.yml` file to your project’s root. Then, from the root of your project, run:
+Copy `example/docker-compose.yml` to your project’s root. Then, from the root of your project, run:
 
 ```bash
 docker-compose up

--- a/README.md
+++ b/README.md
@@ -32,7 +32,15 @@ docker run --rm geoffreybooth/meteor-base:$(cat ./.meteor/release | cut -c8-99) 
 
 Also copy in `example/.dockerignore`
 
-### Step #4 - Use Docker Compose to ease your workflow
+### Step #4 - Build & Profit 🎉
+
+Congratulations, you can know build the Docker image for your Meteor app in an easy and efficient way 🙂
+
+```bash
+docker build -t you-awesome-name/your-meteor-app-name .
+```
+
+### Step #5 (Optional) - Use Docker Compose to ease your workflow
 
 and `example/docker-compose.yml` to your project’s root. Then, from the root of your project:
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ This repo contains a base Docker image for use by [Meteor](https://www.meteor.co
 
 ## Quickstart
 
+### Step #1 - Bootstrap Dockerfile from template
+
 Copy `example/default.dockerfile` (or `example/app-with-native-dependencies.dockerfile` if your app has native dependencies that require compilation such as `bcrypt`, or if your app is using a version of Meteor older than 1.8.1) into the root of your project and rename it `Dockerfile`. This file assumes that your Meteor app is one level down from the root in a folder named `app`; either move your app there, or edit `Dockerfile` to point to your desired path (or the root of your project). Leave `Dockerfile` at the root.
+
+### Step #2 - Ensure the Meteor version is the one you want
 
 Edit the `Dockerfile` you copied into your project, changing the first line so that the numbers at the end match the version of Meteor of your project. For example:
 
@@ -24,7 +28,13 @@ If necessary, update version in the `FROM node` line to use the Node version app
 docker run --rm geoffreybooth/meteor-base:$(cat ./.meteor/release | cut -c8-99) meteor node --version | cut -c2-99 | grep -o "[0-9\.]*"
 ```
 
-Also copy in `example/.dockerignore` and `example/docker-compose.yml` to your project’s root. Then, from the root of your project:
+### Step #3 - Setup your .dockerignore accordingly to speed up builds
+
+Also copy in `example/.dockerignore`
+
+### Step #4 - Use Docker Compose to ease your workflow
+
+and `example/docker-compose.yml` to your project’s root. Then, from the root of your project:
 
 ```bash
 docker-compose up


### PR DESCRIPTION
- 📝 docs(README): add subsections to quickstart to make it more readable
- 📝 docs(README): add a simple build example to the quickstart and mark docker-compose as optional
- 📝 docs(README): make quickstart example in Step 2 a bit more readable
- 📝 docs(README): add details about .dockerignore in Step 3 of Quickstart
- 📝 docs(README): fix presentation of docker-compose section in Quickstart to make sense
- 📝 docs(README): make further instructions have their own "Going further" section
