### PR TITLE
fix #93 apk python alias not working anymore

### DIFF
--- a/example/app-with-native-dependencies.dockerfile
+++ b/example/app-with-native-dependencies.dockerfile
@@ -23,7 +23,7 @@ RUN apk --no-cache add \
 	bash \
 	g++ \
 	make \
-	python
+	python3
 
 # Copy in entrypoint
 COPY --from=0 $SCRIPTS_FOLDER $SCRIPTS_FOLDER/


### PR DESCRIPTION
Fix missing python to python3 alias in alpine apk