### PR TITLE
Remove `hash npm` uses

### DIFF
--- a/src/docker/build-meteor-npm-dependencies.sh
+++ b/src/docker/build-meteor-npm-dependencies.sh
@@ -4,17 +4,11 @@ set -o errexit
 
 printf "\n[-] Installing Meteor application server NPM dependencies...\n\n"
 
-if hash npm 2>/dev/null; then
-	npm_cmd='npm'
-else
-	npm_cmd='meteor npm'
-fi
-
 cd $APP_BUNDLE_FOLDER/bundle/programs/server/
-$npm_cmd install
+npm install
 
 if [[ "$1" = '--build-from-source' ]]; then
-	$npm_cmd rebuild --build-from-source
+	npm rebuild --build-from-source
 	cd $APP_BUNDLE_FOLDER/bundle/programs/server/npm
-	$npm_cmd rebuild --build-from-source
+	npm rebuild --build-from-source
 fi


### PR DESCRIPTION
Proposing removing the use of `hash npm` which breaks in some environments.  

My understanding is that the `meteor` executable does not exist within this layer of the build process, therefore if `hash npm` evaluates to something truthy then `meteor npm` fails.

```sh
if hash npm 2>/dev/null; then
	npm_cmd='npm'
else
	npm_cmd='meteor npm'
fi
```

Is there any use case in which `meteor npm install` _does_ need to run in this build layer?  If not I'm assuming it's safe to remove the conditional logic based on `hash npm` and run `npm install` instead.