### PR TITLE
Correct Node versions for 2.5.6, 2.6, 2.6.1, 2.7, 2.7.1, 2.7.2

### DIFF
--- a/example/app-with-native-dependencies.dockerfile
+++ b/example/app-with-native-dependencies.dockerfile
@@ -13,7 +13,7 @@ RUN bash $SCRIPTS_FOLDER/build-meteor-bundle.sh
 
 
 # Use the specific version of Node expected by your Meteor release, per https://docs.meteor.com/changelog.html; this is expected for Meteor 2.7.2
-FROM node:14.18.3-alpine
+FROM node:14.19.1-alpine
 
 ENV APP_BUNDLE_FOLDER /opt/bundle
 ENV SCRIPTS_FOLDER /docker
@@ -36,7 +36,7 @@ RUN bash $SCRIPTS_FOLDER/build-meteor-npm-dependencies.sh --build-from-source
 
 # Start another Docker stage, so that the final image doesn’t contain the layer with the build dependencies
 # See previous FROM line; this must match
-FROM node:14.18.3-alpine
+FROM node:14.19.1-alpine
 
 ENV APP_BUNDLE_FOLDER /opt/bundle
 ENV SCRIPTS_FOLDER /docker

--- a/example/default.dockerfile
+++ b/example/default.dockerfile
@@ -13,7 +13,7 @@ RUN bash $SCRIPTS_FOLDER/build-meteor-bundle.sh
 
 
 # Use the specific version of Node expected by your Meteor release, per https://docs.meteor.com/changelog.html; this is expected for Meteor 2.7.2
-FROM node:14.18.3-alpine
+FROM node:14.19.1-alpine
 
 ENV APP_BUNDLE_FOLDER /opt/bundle
 ENV SCRIPTS_FOLDER /docker

--- a/test.sh
+++ b/test.sh
@@ -91,11 +91,15 @@ for version in "${meteor_versions[@]}"; do
 	elif [[ "${version}" == 2.5 ]]; then
 		node_version='14.18.1'
 
-	# Versions from 2.5.1 to 2.5.5 are not compatible because the Fibers version is missing binaries.
+	# Versions from 2.5.1 to 2.5.5 are unsupported because the Fibers version is missing binaries
 
-	# Versions >= 2.5.6 need Node 14.18.3
-	else
+	# Versions 2.5.6, 2.6 and 2.6.1 need Node 14.18.3
+	elif [[ "${version}" == 2.5.6 ]] || [[ "${version}" == 2.6 ]] || [[ "${version}" == 2.6.1 ]]; then
 		node_version='14.18.3'
+
+	# Versions >= 2.7 need Node 14.19.1
+	else
+		node_version='14.19.1'
 	fi
 
 	echo 'Creating test app...'


### PR DESCRIPTION
Split off from #115.