### PR TITLE
Update script to automate supporting new Meteor versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ Other projects I looked at generally had one or more of the disadvantages cited 
 Each new Meteor release requires new base images to be built and published. There’s a script in this repo to automate supporting a new Meteor version. For an example Meteor version 7.7.7 that requires Node 8.8.8, run:
 
 ```bash
+# Install Meteor if you haven’t already; see https://www.meteor.com/developers/install
+
+# Install npm-check-updates if you haven’t already
+npm install --global npm-check-updates
+
 ./update.sh --meteor-version 7.7.7 --node-version 8.8.8
 ```
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,19 @@ There are several great Meteor Docker images out there. We built this one becaus
 
 Other projects I looked at generally had one or more of the disadvantages cited above. Multistage Docker builds have only been possible since Docker 17.05, which came out in May 2017, and most projects on the Web were designed before then and therefore don’t take advantage of the possibilities offered by a multistage architecture.
 
-## Test
+## Contributing
+
+### Adding a new Meteor version
+
+Each new Meteor release requires new base images to be built and published. There’s a script in this repo to automate supporting a new Meteor version. For an example Meteor version 7.7.7 that requires Node 8.8.8, run:
+
+```bash
+./update.sh --meteor-version 7.7.7 --node-version 8.8.8
+```
+
+This will update the various files in this repo that need changing for each new Meteor release. Commit this change on a new branch and open a pull request to this repo to get the new version added. Once the PR is merged, `./build.sh && ./test.sh && ./push.sh` will be run to rebuild, test and publish all images for all versions of Meteor ≥ 1.9. This will also update the version of Ubuntu in the base images to the latest Ubuntu version.
+
+### Test
 
 ```bash
 # Build all images

--- a/build.sh
+++ b/build.sh
@@ -1,14 +1,5 @@
 #!/usr/bin/env bash
-set -o errexit
-set -o pipefail
-set -o nounset
-set -o allexport
-
-
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-RED='\033[0;31m'
-NC='\033[0m'
+source ./support.sh
 
 
 build_cmd() {

--- a/example/default.dockerfile
+++ b/example/default.dockerfile
@@ -12,7 +12,7 @@ COPY ./app $APP_SOURCE_FOLDER/
 RUN bash $SCRIPTS_FOLDER/build-meteor-bundle.sh
 
 
-# Use the specific version of Node expected by your Meteor release, per https://docs.meteor.com/changelog.html; this is expected for Meteor 2.7.2
+# Use the specific version of Node expected by your Meteor release, per https://docs.meteor.com/changelog.html; this is expected for Meteor 2.7.3
 FROM node:14.19.3-alpine
 
 ENV APP_BUNDLE_FOLDER /opt/bundle

--- a/push.sh
+++ b/push.sh
@@ -1,14 +1,5 @@
 #!/usr/bin/env bash
-set -o errexit
-set -o pipefail
-set -o nounset
-set -o allexport
-
-
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-RED='\033[0;31m'
-NC='\033[0m'
+source ./support.sh
 
 
 source ./versions.sh

--- a/support.sh
+++ b/support.sh
@@ -1,0 +1,52 @@
+set -o errexit
+set -o pipefail
+set -o nounset
+set -o allexport
+
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+
+do_sed () {
+	if [ "$(uname)" == "Darwin" ]; then # Mac
+		sed -i '' -e "$1" "$2"
+	else # Linux
+		sed --in-place "$1" "$2"
+	fi
+}
+
+
+set_node_version() {
+	# Versions 1.9 through 2.2 need Node 12.22.1
+	if [[ "$1" == 1.9* ]] || \
+		[[ "$1" == 1.10* ]] || \
+		[[ "$1" == 1.11* ]] || \
+		[[ "$1" == 1.12* ]] || \
+		[[ "$1" == 2.0* ]] || \
+		[[ "$1" == 2.1* ]] || \
+		[[ "$1" == 2.2 ]]; then node_version='12.22.1'
+	elif [[ "$1" == 2.2.1 ]]; then node_version='12.22.2'
+	elif [[ "$1" == 2.2.2 ]]; then node_version='12.22.4'
+	elif [[ "$1" == 2.2.3 ]]; then node_version='12.22.5'
+	elif [[ "$1" == 2.3 ]]; then node_version='14.17.1'
+	elif [[ "$1" == 2.3.1 ]]; then node_version='14.17.3'
+	elif [[ "$1" == 2.3.2 ]]; then node_version='14.17.3'
+	elif [[ "$1" == 2.3.3 ]]; then node_version='14.17.4'
+	elif [[ "$1" == 2.3.4 ]]; then node_version='14.17.4'
+	elif [[ "$1" == 2.3.5 ]]; then node_version='14.17.5'
+	elif [[ "$1" == 2.3.6 ]]; then node_version='14.17.6'
+	elif [[ "$1" == 2.4 ]]; then node_version='14.17.6'
+	elif [[ "$1" == 2.5 ]]; then node_version='14.18.1'
+	# Versions from 2.5.1 to 2.5.5 are unsupported because the Fibers version is missing binaries
+	elif [[ "$1" == 2.5.6 ]]; then node_version='14.18.3'
+	elif [[ "$1" == 2.6 ]]; then node_version='14.18.3'
+	elif [[ "$1" == 2.6.1 ]]; then node_version='14.18.3'
+	elif [[ "$1" == 2.7.0 ]]; then node_version='14.19.1'
+	elif [[ "$1" == 2.7.1 ]]; then node_version='14.19.1'
+	elif [[ "$1" == 2.7.2 ]]; then node_version='14.19.1'
+	elif [[ "$1" == 2.7.3 ]]; then node_version='14.19.3'
+	fi # End of versions
+}

--- a/support.sh
+++ b/support.sh
@@ -44,7 +44,7 @@ set_node_version() {
 	elif [[ "$1" == 2.5.6 ]]; then node_version='14.18.3'
 	elif [[ "$1" == 2.6 ]]; then node_version='14.18.3'
 	elif [[ "$1" == 2.6.1 ]]; then node_version='14.18.3'
-	elif [[ "$1" == 2.7.0 ]]; then node_version='14.19.1'
+	elif [[ "$1" == 2.7 ]]; then node_version='14.19.1'
 	elif [[ "$1" == 2.7.1 ]]; then node_version='14.19.1'
 	elif [[ "$1" == 2.7.2 ]]; then node_version='14.19.1'
 	elif [[ "$1" == 2.7.3 ]]; then node_version='14.19.3'

--- a/test.sh
+++ b/test.sh
@@ -65,10 +65,10 @@ for version in "${meteor_versions[@]}"; do
 	do_sed 's|dockerfile: Dockerfile|dockerfile: test.dockerfile|' test.docker-compose.yml
 
 	echo 'Building test app Docker image...'
-	run_with_suppressed_output 'docker-compose --file test.docker-compose.yml build'
+	run_with_suppressed_output 'docker compose --file test.docker-compose.yml build'
 
 	echo 'Launching test app...'
-	run_with_suppressed_output 'docker-compose --file test.docker-compose.yml up --detach'
+	run_with_suppressed_output 'docker compose --file test.docker-compose.yml up --detach'
 
 	# Poll until docker-compose network ready, timing out after 20 seconds
 	for i in {1..20}; do
@@ -97,7 +97,7 @@ for version in "${meteor_versions[@]}"; do
 	fi
 
 	if [ "${SKIP_CLEANUP:-}" != 1 ]; then
-		run_with_suppressed_output 'docker-compose --file test.docker-compose.yml down'
+		run_with_suppressed_output 'docker compose --file test.docker-compose.yml down'
 		run_with_suppressed_output 'docker rmi example_app:latest'
 
 		rm -f test.dockerfile

--- a/test.sh
+++ b/test.sh
@@ -1,14 +1,5 @@
 #!/usr/bin/env bash
-set -o errexit
-set -o pipefail
-set -o nounset
-set -o allexport
-
-
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-RED='\033[0;31m'
-NC='\033[0m'
+source ./support.sh
 
 
 exit_code=0 # Keep global, so that code below can get return value of this function
@@ -18,15 +9,6 @@ run_with_suppressed_output () {
 	if [ $exit_code -ne 0 ]; then
 		echo "$logs"
 		exit $exit_code
-	fi
-}
-
-
-do_sed () {
-	if [ "$(uname)" == "Darwin" ]; then # Mac
-		sed -i '' -e "$1" "$2"
-	else # Linux
-		sed --in-place "$1" "$2"
 	fi
 }
 

--- a/test.sh
+++ b/test.sh
@@ -50,61 +50,8 @@ for version in "${meteor_versions[@]}"; do
 	rm -f test.docker-compose.yml
 	rm -rf test-app
 
-	# Versions 1.9 through 2.2 need Node 12.22.1
 	dockerfile='default.dockerfile'
-	if [[ "${version}" == 1.9* ]] || [[ "${version}" == 1.10* ]] || [[ "${version}" == 1.11* ]] || [[ "${version}" == 1.12* ]] || [[ "${version}" == 2.0* ]] || [[ "${version}" == 2.1* ]] || [[ "${version}" == 2.2 ]]; then
-		node_version='12.22.1'
-
-	# Version 2.2.1 needs Node 12.22.2
-	elif [[ "${version}" == 2.2.1 ]]; then
-		node_version='12.22.2'
-
-	# Version 2.2.2 needs Node 12.22.4
-	elif [[ "${version}" == 2.2.2 ]]; then
-		node_version='12.22.4'
-
-	# Version 2.2.3 needs Node 12.22.5
-	elif [[ "${version}" == 2.2.3 ]]; then
-		node_version='12.22.5'
-
-	# Version 2.3 needs Node 14.17.1
-	elif [[ "${version}" == 2.3 ]]; then
-		node_version='14.17.1'
-
-	# Versions 2.3.1 and 2.3.2 need Node 14.17.3
-	elif [[ "${version}" == 2.3.1 ]] || [[ "${version}" == 2.3.2 ]]; then
-		node_version='14.17.3'
-
-	# Versions 2.3.3 and 2.3.4 need Node 14.17.4
-	elif [[ "${version}" == 2.3.3 ]] || [[ "${version}" == 2.3.4 ]]; then
-		node_version='14.17.4'
-
-	# Version 2.3.5 needs Node 14.17.5
-	elif [[ "${version}" == 2.3.5 ]]; then
-		node_version='14.17.5'
-
-	# Version 2.3.6 and 2.4 need Node 14.17.6
-	elif [[ "${version}" == 2.3.6 ]] || [[ "${version}" == 2.4 ]]; then
-		node_version='14.17.6'
-
-	# Version 2.5 needs Node 14.18.1
-	elif [[ "${version}" == 2.5 ]]; then
-		node_version='14.18.1'
-
-	# Versions from 2.5.1 to 2.5.5 are unsupported because the Fibers version is missing binaries
-
-	# Versions 2.5.6, 2.6 and 2.6.1 need Node 14.18.3
-	elif [[ "${version}" == 2.5.6 ]] || [[ "${version}" == 2.6 ]] || [[ "${version}" == 2.6.1 ]]; then
-		node_version='14.18.3'
-
-	# Versions 2.7.0, 2.7.1, 2.7.2 need Node 14.19.1
-	elif [[ "${version}" == 2.7.0 ]] || [[ "${version}" == 2.7.1 ]] || [[ "${version}" == 2.7.2 ]]; then
-		node_version='14.19.1'
-
-	# Versions >= 2.7.3 need Node 14.19.3
-	else
-		node_version='14.19.3'
-	fi
+	set_node_version "${version}"
 
 	echo 'Creating test app...'
 	run_with_suppressed_output "docker run --rm --volume ${PWD}:/opt/tmp --workdir /opt/tmp geoffreybooth/meteor-base:${version} meteor create --release=${version} test-app"

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+source ./support.sh
+
+
+# Check for dependencies
+
+if ! which meteor > /dev/null ; then
+	echo 'Error: Meteor must be installed.'
+	echo 'See https://www.meteor.com/developers/install'
+	exit 1
+fi
+
+if ! which npm-check-updates > /dev/null ; then
+	echo 'Error: npm-check-updates must be installed:'
+	echo 'npm install --global npm-check-updates'
+	exit 1
+fi
+
+
+# Parse arguments
+
+help() {
+	echo 'Add new Meteor release version, including the version of Node.js that it needs per the Meteor changelog'
+	echo 'syntax: ./update.sh --meteor-version 0.0.0 --node-version 0.0.0'
+}
+
+
+if [ $# -eq 0 ]; then
+	help
+	exit 0
+fi
+
+new_meteor_version=''
+new_node_version=''
+
+while test $# -gt 0; do
+	case "$1" in
+		-h|--help)
+			help
+			exit 0
+			;;
+		--meteor-version)
+			shift;
+			new_meteor_version="$1";
+			shift;
+			;;
+		--node-version)
+			shift;
+			new_node_version="$1";
+			shift;
+			;;
+		*)
+			help
+			exit 0
+			;;
+	esac
+done
+
+
+# Update files for new Meteor version
+
+source ./versions.sh
+newest_meteor_version="${meteor_versions[-1]}"
+
+do_sed $"s|          - '${newest_meteor_version}'|          - '${newest_meteor_version}'\\n          - '${new_meteor_version}'|" ./.github/workflows/continuous-integration-workflow.yml
+
+do_sed "s|${newest_meteor_version}|${new_meteor_version}|" ./README.md
+
+do_sed "s|${newest_meteor_version}|${new_meteor_version}|" ./example/app-with-native-dependencies.dockerfile
+
+# Skip ./example/app/.meteor/release because the Meteor update command below will change it
+
+do_sed "s|${newest_meteor_version}|${new_meteor_version}|" ./example/default.dockerfile
+
+do_sed $"s|'${newest_meteor_version}'|'${newest_meteor_version}' \\\\\n	'${new_meteor_version}'|" ./versions.sh
+
+
+# Update files for new Node version
+
+set_node_version $newest_meteor_version # $node_version is the version of the current newest Meteor version, not the one being added
+
+do_sed "s|${node_version}|${new_node_version}|" ./example/app-with-native-dependencies.dockerfile
+
+do_sed "s|${node_version}|${new_node_version}|" ./example/default.dockerfile
+
+
+# Update example app dependencies
+
+cd example/app
+
+meteor update --release "${new_meteor_version}"
+
+npm-check-updates --configFilePath /dev/null --upgrade
+npm install
+
+cd ../..

--- a/update.sh
+++ b/update.sh
@@ -60,17 +60,17 @@ done
 # Update files for new Meteor version
 
 source ./versions.sh
-newest_meteor_version="${meteor_versions[-1]}"
+newest_meteor_version="${meteor_versions[*]: -1}"
 
 do_sed $"s|          - '${newest_meteor_version}'|          - '${newest_meteor_version}'\\n          - '${new_meteor_version}'|" ./.github/workflows/continuous-integration-workflow.yml
 
-do_sed "s|${newest_meteor_version}|${new_meteor_version}|" ./README.md
+do_sed "s|${newest_meteor_version}|${new_meteor_version}|g" ./README.md
 
-do_sed "s|${newest_meteor_version}|${new_meteor_version}|" ./example/app-with-native-dependencies.dockerfile
+do_sed "s|${newest_meteor_version}|${new_meteor_version}|g" ./example/app-with-native-dependencies.dockerfile
 
 # Skip ./example/app/.meteor/release because the Meteor update command below will change it
 
-do_sed "s|${newest_meteor_version}|${new_meteor_version}|" ./example/default.dockerfile
+do_sed "s|${newest_meteor_version}|${new_meteor_version}|g" ./example/default.dockerfile
 
 do_sed $"s|'${newest_meteor_version}'|'${newest_meteor_version}' \\\\\n	'${new_meteor_version}'|" ./versions.sh
 
@@ -79,9 +79,9 @@ do_sed $"s|'${newest_meteor_version}'|'${newest_meteor_version}' \\\\\n	'${new_m
 
 set_node_version $newest_meteor_version # $node_version is the version of the current newest Meteor version, not the one being added
 
-do_sed "s|${node_version}|${new_node_version}|" ./example/app-with-native-dependencies.dockerfile
+do_sed "s|${node_version}|${new_node_version}|g" ./example/app-with-native-dependencies.dockerfile
 
-do_sed "s|${node_version}|${new_node_version}|" ./example/default.dockerfile
+do_sed "s|${node_version}|${new_node_version}|g" ./example/default.dockerfile
 
 
 # Update example app dependencies

--- a/versions.sh
+++ b/versions.sh
@@ -40,3 +40,36 @@ meteor_versions=( \
 	'2.7.2' \
 	'2.7.3'
 )
+
+
+set_node_version() {
+	# Versions 1.9 through 2.2 need Node 12.22.1
+	if [[ "$1" == 1.9* ]] || \
+		[[ "$1" == 1.10* ]] || \
+		[[ "$1" == 1.11* ]] || \
+		[[ "$1" == 1.12* ]] || \
+		[[ "$1" == 2.0* ]] || \
+		[[ "$1" == 2.1* ]] || \
+		[[ "$1" == 2.2 ]]; then node_version='12.22.1'
+	elif [[ "$1" == 2.2.1 ]]; then node_version='12.22.2'
+	elif [[ "$1" == 2.2.2 ]]; then node_version='12.22.4'
+	elif [[ "$1" == 2.2.3 ]]; then node_version='12.22.5'
+	elif [[ "$1" == 2.3 ]]; then node_version='14.17.1'
+	elif [[ "$1" == 2.3.1 ]]; then node_version='14.17.3'
+	elif [[ "$1" == 2.3.2 ]]; then node_version='14.17.3'
+	elif [[ "$1" == 2.3.3 ]]; then node_version='14.17.4'
+	elif [[ "$1" == 2.3.4 ]]; then node_version='14.17.4'
+	elif [[ "$1" == 2.3.5 ]]; then node_version='14.17.5'
+	elif [[ "$1" == 2.3.6 ]]; then node_version='14.17.6'
+	elif [[ "$1" == 2.4 ]]; then node_version='14.17.6'
+	elif [[ "$1" == 2.5 ]]; then node_version='14.18.1'
+	# Versions from 2.5.1 to 2.5.5 are unsupported because the Fibers version is missing binaries
+	elif [[ "$1" == 2.5.6 ]]; then node_version='14.18.3'
+	elif [[ "$1" == 2.6 ]]; then node_version='14.18.3'
+	elif [[ "$1" == 2.6.1 ]]; then node_version='14.18.3'
+	elif [[ "$1" == 2.7.0 ]]; then node_version='14.19.1'
+	elif [[ "$1" == 2.7.1 ]]; then node_version='14.19.1'
+	elif [[ "$1" == 2.7.2 ]]; then node_version='14.19.1'
+	elif [[ "$1" == 2.7.3 ]]; then node_version='14.19.3'
+	fi # End of versions
+}

--- a/versions.sh
+++ b/versions.sh
@@ -40,36 +40,3 @@ meteor_versions=( \
 	'2.7.2' \
 	'2.7.3'
 )
-
-
-set_node_version() {
-	# Versions 1.9 through 2.2 need Node 12.22.1
-	if [[ "$1" == 1.9* ]] || \
-		[[ "$1" == 1.10* ]] || \
-		[[ "$1" == 1.11* ]] || \
-		[[ "$1" == 1.12* ]] || \
-		[[ "$1" == 2.0* ]] || \
-		[[ "$1" == 2.1* ]] || \
-		[[ "$1" == 2.2 ]]; then node_version='12.22.1'
-	elif [[ "$1" == 2.2.1 ]]; then node_version='12.22.2'
-	elif [[ "$1" == 2.2.2 ]]; then node_version='12.22.4'
-	elif [[ "$1" == 2.2.3 ]]; then node_version='12.22.5'
-	elif [[ "$1" == 2.3 ]]; then node_version='14.17.1'
-	elif [[ "$1" == 2.3.1 ]]; then node_version='14.17.3'
-	elif [[ "$1" == 2.3.2 ]]; then node_version='14.17.3'
-	elif [[ "$1" == 2.3.3 ]]; then node_version='14.17.4'
-	elif [[ "$1" == 2.3.4 ]]; then node_version='14.17.4'
-	elif [[ "$1" == 2.3.5 ]]; then node_version='14.17.5'
-	elif [[ "$1" == 2.3.6 ]]; then node_version='14.17.6'
-	elif [[ "$1" == 2.4 ]]; then node_version='14.17.6'
-	elif [[ "$1" == 2.5 ]]; then node_version='14.18.1'
-	# Versions from 2.5.1 to 2.5.5 are unsupported because the Fibers version is missing binaries
-	elif [[ "$1" == 2.5.6 ]]; then node_version='14.18.3'
-	elif [[ "$1" == 2.6 ]]; then node_version='14.18.3'
-	elif [[ "$1" == 2.6.1 ]]; then node_version='14.18.3'
-	elif [[ "$1" == 2.7.0 ]]; then node_version='14.19.1'
-	elif [[ "$1" == 2.7.1 ]]; then node_version='14.19.1'
-	elif [[ "$1" == 2.7.2 ]]; then node_version='14.19.1'
-	elif [[ "$1" == 2.7.3 ]]; then node_version='14.19.3'
-	fi # End of versions
-}


### PR DESCRIPTION
I've added an `update.sh` script to automate the process of adding a new Meteor version, including updating the required Node version and example app dependencies. This should hopefully make the process of adding new versions more streamlined and less error-prone.