### PR TITLE
added 2.5.7

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -43,6 +43,7 @@ jobs:
           # - '2.5.4' # Fibers is missing binaries
           # - '2.5.5' # Fibers is missing binaries
           - '2.5.6'
+          - '2.5.7'
           - '2.6'
           - '2.6.1'
           - '2.7'

--- a/support.sh
+++ b/support.sh
@@ -42,6 +42,7 @@ set_node_version() {
 	elif [[ "$1" == 2.5 ]]; then node_version='14.18.1'
 	# Versions from 2.5.1 to 2.5.5 are unsupported because the Fibers version is missing binaries
 	elif [[ "$1" == 2.5.6 ]]; then node_version='14.18.3'
+	elif [[ "$1" == 2.5.7 ]]; then node_version='14.19.3'
 	elif [[ "$1" == 2.6 ]]; then node_version='14.18.3'
 	elif [[ "$1" == 2.6.1 ]]; then node_version='14.18.3'
 	elif [[ "$1" == 2.7 ]]; then node_version='14.19.1'

--- a/versions.sh
+++ b/versions.sh
@@ -33,6 +33,7 @@ meteor_versions=( \
 	# '2.5.4' \ # Fibers is missing binaries
 	# '2.5.5' \ # Fibers is missing binaries
 	'2.5.6' \
+	'2.5.7' \
 	'2.6' \
 	'2.6.1' \
 	'2.7' \


### PR DESCRIPTION
2.5.7 was released. I didn't use the ./update.sh script since it's not the latest release. Important update to the latest release that doesn't include major mongo changes.

https://github.com/meteor/meteor/pull/12054/commits/87407fb0e27f2b2a17354816261fb58597ace70c