### PR TITLE
Fix: Add line to update support.sh file

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -83,6 +83,8 @@ do_sed "s|${node_version}|${new_node_version}|g" ./example/app-with-native-depen
 
 do_sed "s|${node_version}|${new_node_version}|g" ./example/default.dockerfile
 
+do_sed $"s|'${node_version}'|'${node_version}'\\n	elif [[ \"\$1\" == ${new_meteor_version} ]]; then node_version='${new_node_version}'|" ./support.sh
+
 
 # Update example app dependencies
 


### PR DESCRIPTION
### Description

`Support.sh` file was missing to update with the new meteor and node versions.

### Test

_./update.sh --meteor-version 2.8.1-beta.0 --node-version 14.21.0_

<img width="574" alt="Screen Shot 2022-10-27 at 19 03 15" src="https://user-images.githubusercontent.com/39581375/198420028-1610d4aa-2c1c-4a2d-a2b5-7d7408299c83.png">
