### PR TITLE
Modify Dockerfile and examples to only run necessary commands as root

### DIFF
--- a/example/default.dockerfile
+++ b/example/default.dockerfile
@@ -1,13 +1,15 @@
 # The tag here should match the Meteor version of your app, per .meteor/release
-FROM geoffreybooth/meteor-base:2.11.0
+FROM geoffreybooth/meteor-base:2.11.0 AS bundler
+
+USER node:node
 
 # Copy app package.json and package-lock.json into container
-COPY ./app/package*.json $APP_SOURCE_FOLDER/
+COPY --chown=node:node ./app/package*.json $APP_SOURCE_FOLDER/
 
 RUN bash $SCRIPTS_FOLDER/build-app-npm-dependencies.sh
 
 # Copy app source into container
-COPY ./app $APP_SOURCE_FOLDER/
+COPY --chown=node:node ./app $APP_SOURCE_FOLDER/
 
 RUN bash $SCRIPTS_FOLDER/build-meteor-bundle.sh
 
@@ -15,23 +17,27 @@ RUN bash $SCRIPTS_FOLDER/build-meteor-bundle.sh
 # Use the specific version of Node expected by your Meteor release, per https://docs.meteor.com/changelog.html; this is expected for Meteor 2.11.0
 FROM node:14.21.3-alpine
 
-ENV APP_BUNDLE_FOLDER /opt/bundle
-ENV SCRIPTS_FOLDER /docker
+ENV NODE_HOME /home/node
+ENV APP_BUNDLE_FOLDER $NODE_HOME/bundle
+ENV SCRIPTS_FOLDER $NODE_HOME/docker
 
 # Runtime dependencies; if your dependencies need compilation (native modules such as bcrypt) or you are using Meteor <1.8.1, use app-with-native-dependencies.dockerfile instead
 RUN apk --no-cache add \
 		bash \
 		ca-certificates
 
+# Principal of Least Privilege, should not run as root
+USER node:node
+
 # Copy in entrypoint
-COPY --from=0 $SCRIPTS_FOLDER $SCRIPTS_FOLDER/
+COPY --from=bundler $SCRIPTS_FOLDER $SCRIPTS_FOLDER/
 
 # Copy in app bundle
-COPY --from=0 $APP_BUNDLE_FOLDER/bundle $APP_BUNDLE_FOLDER/bundle/
+COPY --from=bundler $APP_BUNDLE_FOLDER/bundle $APP_BUNDLE_FOLDER/bundle/
 
 RUN bash $SCRIPTS_FOLDER/build-meteor-npm-dependencies.sh
 
 # Start app
-ENTRYPOINT ["/docker/entrypoint.sh"]
+ENTRYPOINT ["/home/node/docker/entrypoint.sh"]
 
 CMD ["node", "main.js"]

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,20 +1,24 @@
 # Based on:
 # - https://github.com/jshimko/meteor-launchpad/blob/master/Dockerfile
 # - https://github.com/meteor/galaxy-images/blob/master/ubuntu/Dockerfile
-FROM ubuntu
+ARG NODE_VERSION=14.21.3
+FROM node:$NODE_VERSION
 
 # Meteor version to build for; see ../build.sh
 ARG METEOR_VERSION
 
-ENV SCRIPTS_FOLDER /docker
-ENV APP_SOURCE_FOLDER /opt/src
-ENV APP_BUNDLE_FOLDER /opt/bundle
+ENV NODE_HOME=/home/node
+ENV SCRIPTS_FOLDER $NODE_HOME/docker
+ENV APP_SOURCE_FOLDER $NODE_HOME/src
+ENV APP_BUNDLE_FOLDER $NODE_HOME/bundle
 
 # Install dependencies, based on https://github.com/jshimko/meteor-launchpad/blob/master/scripts/install-deps.sh (only the parts we plan to use)
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
 	apt-get install --assume-yes apt-transport-https ca-certificates && \
 	apt-get install --assume-yes --no-install-recommends build-essential bzip2 curl git libarchive-tools python3
+
+USER node:node
 
 # Install Meteor
 RUN curl https://install.meteor.com/?release=$METEOR_VERSION --output /tmp/install-meteor.sh && \
@@ -24,12 +28,13 @@ RUN curl https://install.meteor.com/?release=$METEOR_VERSION --output /tmp/insta
 	printf "\n[-] Installing Meteor $METEOR_VERSION...\n\n" && \
 	sh /tmp/install-meteor.sh
 
-# Fix permissions warning; https://github.com/meteor/meteor/issues/7959
-ENV METEOR_ALLOW_SUPERUSER true
-
+# Workaround not being able to sudo to install global meteor bin
+USER root
+RUN cp "$NODE_HOME/.meteor/$(dirname $(readlink "$NODE_HOME/.meteor/meteor"))/scripts/admin/launch-meteor" /usr/local/bin/meteor
+USER node:node
 
 # Copy entrypoint and dependencies
-COPY ./docker $SCRIPTS_FOLDER/
+COPY --chown=node:node ./docker $SCRIPTS_FOLDER/
 
 # Install Docker entrypoint dependencies; npm ci was added in npm 5.7.0, and therefore available only to Meteor 1.7+
 RUN cd $SCRIPTS_FOLDER && \


### PR DESCRIPTION
I found this image as it seems to be the only active production meteor docker image that builds in-docker. I was surprised to find that it runs everything as root as this goes against security best practices for docker images. I made a version that uses the `node` image for all steps so that the same user exists without having to create it, and that `node` user is used for all steps that don't need root.

I wouldn't merge this as-is as it'll break things for existing users, but I think it would make sense to use this in some way, for example by also publishing a `-no-root` variant of the image and giving an example dockerfile that uses it.

A nice addition would be to use the `support.sh` script to set the correct `node` image version to use to build each image, but I haven't done this as I wanted to know if it would be used before putting effort into it.

My build of the image is available [here](https://hub.docker.com/r/piemonkey/meteor-base) for anyone who wants to test or use without having to build yourself.