### PR TITLE
Fix: handle node image transition

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -80,7 +80,7 @@ set_node_version $newest_meteor_version # $node_version is the version of the cu
 
 # For 14.21.4 <= $new_node_version < 18.0.0, we need to use the Meteor fork of the Node Docker image; else, we use the regular official Node Docker image
 
-if [[ $(get_version_string "${new_node_version}") -ge $(get_version_string 14.21.4) && $(get_version_string "${new_node_version}") -lt $(get_version_string 18.0.0) ]]; then
+if [[ $(get_version_string "${new_node_version}") -ge $(get_version_string 18.0.0) ]]; then
 
 	node_image_keyword='node:'
 	meteor_node_image_keyword='meteor/node:'
@@ -88,17 +88,17 @@ if [[ $(get_version_string "${new_node_version}") -ge $(get_version_string 14.21
 	node_alpine_keyword='alpine'
 	meteor_node_alpine_keyword='alpine3.17'
 
-	do_sed "s|${node_image_keyword}|${meteor_node_image_keyword}|g" ./example/app-with-native-dependencies.dockerfile
+	do_sed "s|${meteor_node_image_keyword}|${node_image_keyword}|g" ./example/app-with-native-dependencies.dockerfile
 
 	do_sed "s|${node_version}|${new_node_version}|g" ./example/app-with-native-dependencies.dockerfile
 
-	do_sed "s|${node_alpine_keyword}|${meteor_node_alpine_keyword}|g" ./example/app-with-native-dependencies.dockerfile
+	do_sed "s|${meteor_node_alpine_keyword}|${node_alpine_keyword}|g" ./example/app-with-native-dependencies.dockerfile
 
-	do_sed "s|${node_image_keyword}|${meteor_node_image_keyword}|g" ./example/default.dockerfile
+	do_sed "s|${meteor_node_image_keyword}|${node_image_keyword}|g" ./example/default.dockerfile
 
 	do_sed "s|${node_version}|${new_node_version}|g" ./example/default.dockerfile
 
-	do_sed "s|${node_alpine_keyword}|${meteor_node_alpine_keyword}|g" ./example/default.dockerfile
+	do_sed "s|${meteor_node_alpine_keyword}|${node_alpine_keyword}|g" ./example/default.dockerfile
 
 else
 


### PR DESCRIPTION
With this fix it should now just change the version until Node 18, when it'll be back to the official Node image.
After Node 18, it'll continue to work fine, but the code will be unecessary.