### PR TITLE
fix: update.sh adds multiple lines to supports.sh #155

### DIFF
--- a/support.sh
+++ b/support.sh
@@ -28,6 +28,7 @@ do_tac () {
 			tail -r "$1"
     fi
 	else # Linux
+		# linux doesn't have -r option for tail
 		if (( $# == 0 )) ; then
       tac < /dev/stdin
     else

--- a/support.sh
+++ b/support.sh
@@ -18,6 +18,24 @@ do_sed () {
 	fi
 }
 
+# Reverse the file from filename or stdin
+do_tac () {
+	if [ "$(uname)" == "Darwin" ]; then # Mac
+		# macOS doesn't have tac, so we use tail -r
+		if (( $# == 0 )) ; then
+      tail -r < /dev/stdin
+    else
+			tail -r "$1"
+    fi
+	else # Linux
+		if (( $# == 0 )) ; then
+      tac < /dev/stdin
+    else
+			tac "$1"
+    fi
+	fi
+}
+
 
 set_node_version() {
 	# Versions 1.9 through 2.2 need Node 12.22.1
@@ -61,9 +79,7 @@ set_node_version() {
 	elif [[ "$1" == 2.11.0 ]]; then node_version='14.21.3'
 	elif [[ "$1" == 2.12 ]]; then node_version='14.21.3'
 	elif [[ "$1" == 2.13 ]]; then node_version='14.21.4'
-	elif [[ "$1" == 2.14 ]]; then node_version='14.21.4'
 	elif [[ "$1" == 2.13.1 ]]; then node_version='14.21.4'
-	elif [[ "$1" == 2.14 ]]; then node_version='14.21.4'
 	elif [[ "$1" == 2.13.3 ]]; then node_version='14.21.4'
 	elif [[ "$1" == 2.14 ]]; then node_version='14.21.4'
 	fi # End of versions

--- a/support.sh
+++ b/support.sh
@@ -23,17 +23,17 @@ do_tac () {
 	if [ "$(uname)" == "Darwin" ]; then # Mac
 		# macOS doesn't have tac, so we use tail -r
 		if (( $# == 0 )) ; then
-      tail -r < /dev/stdin
-    else
+			tail -r < /dev/stdin
+		else
 			tail -r "$1"
-    fi
+		fi
 	else # Linux
 		# linux doesn't have -r option for tail
 		if (( $# == 0 )) ; then
-      tac < /dev/stdin
-    else
+			tac < /dev/stdin
+		else
 			tac "$1"
-    fi
+		fi
 	fi
 }
 

--- a/update.sh
+++ b/update.sh
@@ -108,7 +108,16 @@ else
 
 fi
 
-do_sed $"s|'${node_version}'|'${node_version}'\\n	elif [[ \"\$1\" == ${new_meteor_version} ]]; then node_version='${new_node_version}'|" ./support.sh
+
+# Use cat here because the file is being written to in the same command
+# Reverse the file, replace the first occurrence of the current node version with __XXXXXX__ as placeholder,
+# reverse the file back, replace __XXXXXX__ back and add new line for the new Meteor version, and write the file back
+cat ./support.sh \
+	| do_tac \
+	| sed "1,/'${node_version}'/s|'${node_version}'|'__XXXXXX__'|" \
+	| do_tac \
+	| sed "s|'__XXXXXX__'|'${node_version}'\\n	elif [[ \"\$1\" == ${new_meteor_version} ]]; then node_version='${new_node_version}'|" \
+	| tee -i ./support.sh > /dev/null
 
 
 # Update example app dependencies


### PR DESCRIPTION
The issue in update.sh was due $ is treated as address and means end of file in this line:

```bash
do_sed $"s|'${node_version}'|'${node_version}'\\n	elif [[ \"\$1\" == ${new_meteor_version} ]]; then node_version='${new_node_version}'|" ./support.sh
```
As sed works line by line there is no simple way to tell sed use the latest occurrence in the file (well at least I didn't find that). So my approach is a bit complicated but works well:
- reverse file and replace node version with a temporary string
- reverse file back and then reverse temporary string with what we need

-ap
